### PR TITLE
Switch to tag for version constraint on google/apiclient dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ test:
 
 install:
 	docker-compose run --rm test composer install
+
+update:
+	docker-compose run --rm test composer update

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.4",
         "ext-json": "*",
-        "google/apiclient": "1.1.x-dev#19d7d735ee4cff0f8c14a234b5094b99d00ef278",
+        "google/apiclient": "^v1.1.9",
         "google/apiclient-services": "^0.176"
     },
     "require-dev": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     test:
-        image: php:7.4-apache
+        image: silintl/php7:7.4
         env_file:
           - local.env
         volumes:


### PR DESCRIPTION
### Fixed
- Switch to tag for version constraint on `google/apiclient` dependency
- Use our standard PHP 7.4 Docker image for tests and composer updates

### Added
- Add a `make update` command for easier updating of dependencies

---

That `v1.1.9` tag refers to the exact commit we'd been using (`19d7d735`).