### PR TITLE
Release 1.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,8 @@
 {
+    "name": "silinternational/google-sheets-php",
+    "description": "A simple library for pushing data to a Google Sheet using the Google PHP API Client version 1",
+    "type": "library",
+    "license": "MIT",
     "require": {
         "php": "^7.2",
         "ext-json": "*",

--- a/features/context/GoogleSheetsContext.php
+++ b/features/context/GoogleSheetsContext.php
@@ -1,14 +1,12 @@
 <?php
 namespace Sil\GoogleSheets\features\context;
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Behat\Context\Context;
 use Sil\GoogleSheets\GoogleSheets;
 use Sil\PhpEnv\Env;
 
 class GoogleSheetsContext implements Context
 {
-    private $exceptionThrown;
     private $googleSheets;
     
     public function __construct()


### PR DESCRIPTION
### Fixed
- Switch to tag for version constraint on `google/apiclient` dependency
- Use our standard PHP 7.4 Docker image for tests and composer updates

### Added
- Add a `make update` command for easier updating of dependencies

---

That `v1.1.9` tag refers to the exact commit we'd been using (`19d7d735`).